### PR TITLE
feat: Permit #report in every Nginx phase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM openresty/openresty:1.11.2.5-jessie
-MAINTAINER Scalingo Team "tech@scalingo.com"
+FROM openresty/openresty:1.27.1.1-jammy
+
+LABEL maintainer="Scalingo Team <tech@scalingo.com>"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-    && apt-get install --yes git \
+    && apt-get install -y --no-install-recommends git \
     && DEBIAN_FRONTEND=noninteractive apt-get autoremove --yes \
     && rm -rf /var/lib/apt/lists/*
 
@@ -12,13 +13,7 @@ RUN luarocks install lua-cjson
 
 # Install the test framework:
 RUN luarocks install busted
-# We actually can't use the LuaRocks version as it contains a blocking bug
-# (https://github.com/thibaultcha/lua-resty-busted/issues/1) which is fixed on master.
-# RUN luarocks install lua-resty-busted
-RUN git clone https://github.com/thibaultcha/lua-resty-busted /tmp/lua-resty-busted \
-    && cp /tmp/lua-resty-busted/bin/busted /usr/local/bin \
-    && chmod +x /usr/local/bin/busted \
-    && rm -fr /tmp/lua-resty-busted
+RUN luarocks install lua-resty-busted
 
 COPY ./entrypoint.sh /
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lua-resty-rollbar [ ![Codeship Status for Scalingo/lua-resty-rollbar](https://app.codeship.com/projects/d0902e10-6667-0136-c148-5e8eddb6d7b2/status?branch=master)](https://app.codeship.com/projects/297381)
+# lua-resty-rollbar [![Codeship Status for Scalingo/lua-resty-rollbar](https://app.codeship.com/projects/d0902e10-6667-0136-c148-5e8eddb6d7b2/status?branch=master)](https://app.codeship.com/projects/297381)
 
 Simple module for [OpenResty](http://openresty.org/) to send errors to
 [Rollbar](https://rollbar.com).
@@ -10,7 +10,7 @@ stack traces. Errors are sent to Rollbar asynchronously in a light thread.
 
 Install using LuaRocks:
 
-```
+```bash
 luarocks install lua-resty-rollbar 0.1.0
 ```
 
@@ -19,14 +19,23 @@ luarocks install lua-resty-rollbar 0.1.0
 ```lua
 local rollbar = require 'resty.rollbar'
 
+-- Set your Rollbar token
+-- This token must have 'post_server_item' scope
 rollbar.set_token('MY_TOKEN')
-rollbar.set_environment('production') -- defaults to 'development'
+-- Set the set_environment. Defaults to 'development'
+rollbar.set_environment('production')
 
 function main()
-	res, err = do_something()
+	local res, err = do_something()
 	if not res {
-		// Error reporting
+		-- Error reporting
+		-- This function will automatically read request information (URI, method,...) if available before reporting the error to Rollbar
 		rollbar.report(rollbar.ERR, err)
+
+		-- If the error reporting occurs from outside a request context (eg. inside a timer), you can supply a third parameter to prevent
+		-- an useless function call that will try to read non existing request information
+		rollbar.report(rollbar.ERR, err, {})
+
 		return
 	}
 end
@@ -40,19 +49,19 @@ to execute the unit tests.
 
 Run the Docker Compose container in a terminal:
 
-```
+```bash
 docker-compose up
 ```
 
 In a different terminal, execute the tests with:
 
-```
+```bash
 docker-compose exec test busted specs
 ```
 
 ## Publish on LuaRocks
 
-```
+```bash
 luarocks upload --api-key=<API key> ./lua-resty-rollbar-0.1.0-1.rockspec
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ to execute the unit tests.
 Run the Docker Compose container in a terminal:
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 In a different terminal, execute the tests with:
 
 ```bash
-docker-compose exec test busted specs
+docker compose exec test busted specs
 ```
 
 ## Publish on LuaRocks

--- a/bin/setup-codeship
+++ b/bin/setup-codeship
@@ -5,12 +5,13 @@ set -o errexit
 
 # The VERSION environment variables are defined in Codeship environment
 # (https://app.codeship.com/projects/297381/environment/edit)
-RESTY_VERSION="${RESTY_VERSION:-1.25.3.1}"
-RESTY_LUAROCKS_VERSION="${RESTY_LUAROCKS_VERSION:-3.9.2}"
-RESTY_OPENSSL_VERSION="${RESTY_OPENSSL_VERSION:-1.1.1w}"
-RESTY_OPENSSL_PATCH_VERSION="${RESTY_OPENSSL_PATCH_VERSION:-1.1.1f}"
-RESTY_PCRE_VERSION="${RESTY_PCRE_VERSION:-8.45}"
-RESTY_PCRE_SHA256="4e6ce03e0336e8b4a3d6c2b70b1c5e18590a5673a98186da90d4f33c23defc09"
+RESTY_VERSION="${RESTY_VERSION:-1.27.1.1}"
+RESTY_LUAROCKS_VERSION="${RESTY_LUAROCKS_VERSION:-3.11.1}"
+RESTY_OPENSSL_VERSION="${RESTY_OPENSSL_VERSION:-3.0.16}"
+RESTY_OPENSSL_PATCH_VERSION="${RESTY_OPENSSL_PATCH_VERSION:-3.0.15}"
+RESTY_OPENSSL_URL_BASE="https://github.com/openssl/openssl/releases/download/openssl-${RESTY_OPENSSL_VERSION}"
+RESTY_PCRE_VERSION="${RESTY_PCRE_VERSION:-10.44}"
+RESTY_PCRE_SHA256="86b9cb0aa3bcb7994faa88018292bc704cdbb708e785f7c74352ff6ea7d3175b"
 
 RESTY_HOME="$HOME/cache/openresty"
 RESTY_J="1"
@@ -48,68 +49,75 @@ if [[ ! -f "$RESTY_HOME/.versions" ]] || [[ "${VERSIONS}" != "$(cat $RESTY_HOME/
 
   _RESTY_CONFIG_DEPS="--with-pcre \
   --prefix=${RESTY_HOME} \
-  --with-cc-opt='-DNGX_LUA_ABORT_AT_PANIC -I${RESTY_HOME}/pcre/include -I${RESTY_HOME}/openssl/include' \
-  --with-ld-opt='-L${RESTY_HOME}/pcre/lib -L${RESTY_HOME}/openssl/lib -Wl,-rpath,${RESTY_HOME}/pcre/lib:${RESTY_HOME}/openssl/lib' \
+  --with-cc-opt='-DNGX_LUA_ABORT_AT_PANIC -I${RESTY_HOME}/pcre2/include -I${RESTY_HOME}/openssl3/include' \
+  --with-ld-opt='-L${RESTY_HOME}/pcre2/lib -L${RESTY_HOME}/openssl3/lib -Wl,-rpath,${RESTY_HOME}/pcre2/lib:${RESTY_HOME}/openssl3/lib' \
   "
 
   cd /tmp \
-  && curl -fSL "https://www.openssl.org/source/openssl-${RESTY_OPENSSL_VERSION}.tar.gz" -o openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
+  && if [ -n "${RESTY_EVAL_PRE_CONFIGURE}" ]; then eval $(echo ${RESTY_EVAL_PRE_CONFIGURE}); fi \
+  && curl -fSL "${RESTY_OPENSSL_URL_BASE}/openssl-${RESTY_OPENSSL_VERSION}.tar.gz" -o openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
   && tar xzf openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
   && cd openssl-${RESTY_OPENSSL_VERSION} \
+  && if [ $(echo ${RESTY_OPENSSL_VERSION} | cut -c 1-4) = "3.0." ] ; then \
+  echo 'patching OpenSSL 3.0.15 for OpenResty' \
+  && curl -s https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-${RESTY_OPENSSL_PATCH_VERSION}-sess_set_get_cb_yield.patch | patch -p1 ; \
+  fi \
   && if [ $(echo ${RESTY_OPENSSL_VERSION} | cut -c 1-5) = "1.1.1" ] ; then \
-      echo 'patching OpenSSL 1.1.1 for OpenResty' \
-      && curl -s https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-${RESTY_OPENSSL_PATCH_VERSION}-sess_set_get_cb_yield.patch | patch -p1 ; \
+  echo 'patching OpenSSL 1.1.1 for OpenResty' \
+  && curl -s https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-${RESTY_OPENSSL_PATCH_VERSION}-sess_set_get_cb_yield.patch | patch -p1 ; \
   fi \
   && if [ $(echo ${RESTY_OPENSSL_VERSION} | cut -c 1-5) = "1.1.0" ] ; then \
-      echo 'patching OpenSSL 1.1.0 for OpenResty' \
-      && curl -s https://raw.githubusercontent.com/openresty/openresty/ed328977028c3ec3033bc25873ee360056e247cd/patches/openssl-1.1.0j-parallel_build_fix.patch | patch -p1 \
-      && curl -s https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-${RESTY_OPENSSL_PATCH_VERSION}-sess_set_get_cb_yield.patch | patch -p1 ; \
+  echo 'patching OpenSSL 1.1.0 for OpenResty' \
+  && curl -s https://raw.githubusercontent.com/openresty/openresty/ed328977028c3ec3033bc25873ee360056e247cd/patches/openssl-1.1.0j-parallel_build_fix.patch | patch -p1 \
+  && curl -s https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-${RESTY_OPENSSL_PATCH_VERSION}-sess_set_get_cb_yield.patch | patch -p1 ; \
   fi \
   && ./config \
-    no-threads shared zlib -g \
-    enable-ssl3 enable-ssl3-method \
-    --prefix=${RESTY_HOME}/openssl \
-    --libdir=lib \
-    -Wl,-rpath,${RESTY_HOME}/openssl/lib \
+  shared zlib -g \
+  --prefix=${RESTY_HOME}/openssl3 \
+  --libdir=lib \
+  -Wl,-rpath,${RESTY_HOME}/openssl3/lib \
+  ${RESTY_OPENSSL_BUILD_OPTIONS} \
   && make -j${RESTY_J} \
   && make -j${RESTY_J} install_sw \
   && cd /tmp \
-  && curl -fSL https://downloads.sourceforge.net/project/pcre/pcre/${RESTY_PCRE_VERSION}/pcre-${RESTY_PCRE_VERSION}.tar.gz -o pcre-${RESTY_PCRE_VERSION}.tar.gz \
-  && echo "${RESTY_PCRE_SHA256}  pcre-${RESTY_PCRE_VERSION}.tar.gz" | shasum -a 256 --check \
-  && tar xzf pcre-${RESTY_PCRE_VERSION}.tar.gz \
-  && cd /tmp/pcre-${RESTY_PCRE_VERSION} \
-  && ./configure \
-      --prefix=${RESTY_HOME}/pcre \
-      --disable-cpp \
-      --enable-utf \
-      --enable-unicode-properties \
-      --enable-jit \
-  && make -j${RESTY_J} \
-  && make -j${RESTY_J} install \
+  && curl -fSL "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${RESTY_PCRE_VERSION}/pcre2-${RESTY_PCRE_VERSION}.tar.gz" -o pcre2-${RESTY_PCRE_VERSION}.tar.gz \
+  && echo "${RESTY_PCRE_SHA256}  pcre2-${RESTY_PCRE_VERSION}.tar.gz" | shasum -a 256 --check \
+  && tar xzf pcre2-${RESTY_PCRE_VERSION}.tar.gz \
+  && cd /tmp/pcre2-${RESTY_PCRE_VERSION} \
+  && CFLAGS="-g -O3" ./configure \
+  --prefix=${RESTY_HOME}/pcre2 \
+  --libdir=${RESTY_HOME}/pcre2/lib \
+  ${RESTY_PCRE_BUILD_OPTIONS} \
+  && CFLAGS="-g -O3" make -j${RESTY_J} \
+  && CFLAGS="-g -O3" make -j${RESTY_J} install \
   && cd /tmp \
   && curl -fSL https://openresty.org/download/openresty-${RESTY_VERSION}.tar.gz -o openresty-${RESTY_VERSION}.tar.gz \
   && tar xzf openresty-${RESTY_VERSION}.tar.gz \
   && cd /tmp/openresty-${RESTY_VERSION} \
-  && eval ./configure -j${RESTY_J} ${_RESTY_CONFIG_DEPS} ${RESTY_CONFIG_OPTIONS} ${RESTY_LUAJIT_OPTIONS} ${RESTY_PCRE_OPTIONS} \
+  && if [ -n "${RESTY_EVAL_POST_DOWNLOAD_PRE_CONFIGURE}" ]; then eval $(echo ${RESTY_EVAL_POST_DOWNLOAD_PRE_CONFIGURE}); fi \
+  && eval ./configure -j${RESTY_J} ${_RESTY_CONFIG_DEPS} ${RESTY_CONFIG_OPTIONS} ${RESTY_CONFIG_OPTIONS_MORE} ${RESTY_LUAJIT_OPTIONS} ${RESTY_PCRE_OPTIONS} \
   && make -j${RESTY_J} \
   && make -j${RESTY_J} install \
   && cd /tmp \
   && rm -rf \
-      openssl-${RESTY_OPENSSL_VERSION}.tar.gz openssl-${RESTY_OPENSSL_VERSION} \
-      pcre-${RESTY_PCRE_VERSION}.tar.gz pcre-${RESTY_PCRE_VERSION} \
-      openresty-${RESTY_VERSION}.tar.gz openresty-${RESTY_VERSION} \
+  openssl-${RESTY_OPENSSL_VERSION}.tar.gz openssl-${RESTY_OPENSSL_VERSION} \
+  pcre2-${RESTY_PCRE_VERSION}.tar.gz pcre2-${RESTY_PCRE_VERSION} \
+  openresty-${RESTY_VERSION}.tar.gz openresty-${RESTY_VERSION} \
   && curl -fSL https://luarocks.github.io/luarocks/releases/luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz -o luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
   && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
   && cd luarocks-${RESTY_LUAROCKS_VERSION} \
   && ./configure \
-      --prefix=${RESTY_HOME}/luajit \
-      --with-lua=${RESTY_HOME}/luajit \
-      --lua-suffix=jit-2.1.0-beta3 \
-      --with-lua-include=${RESTY_HOME}/luajit/include/luajit-2.1 \
+  --prefix=${RESTY_HOME}/luajit \
+  --with-lua=${RESTY_HOME}/luajit \
+  --with-lua-include=${RESTY_HOME}/luajit/include/luajit-2.1 \
   && make build \
   && make install \
   && cd /tmp \
+  && if [ -n "${RESTY_EVAL_POST_MAKE}" ]; then eval $(echo ${RESTY_EVAL_POST_MAKE}); fi \
   && rm -rf luarocks-${RESTY_LUAROCKS_VERSION} luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
+  && if [ -n "${RESTY_ADD_PACKAGE_BUILDDEPS}" ]; then DEBIAN_FRONTEND=noninteractive apt-get remove -y --purge ${RESTY_ADD_PACKAGE_BUILDDEPS} ; fi \
+  && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
+  && mkdir -p /var/run/openresty \
   && ln -sf /dev/stdout ${RESTY_HOME}/nginx/logs/access.log \
   && ln -sf /dev/stderr ${RESTY_HOME}/nginx/logs/error.log
 

--- a/bin/setup-codeship
+++ b/bin/setup-codeship
@@ -113,9 +113,9 @@ if [[ ! -f "$RESTY_HOME/.versions" ]] || [[ "${VERSIONS}" != "$(cat $RESTY_HOME/
   && ln -sf /dev/stdout ${RESTY_HOME}/nginx/logs/access.log \
   && ln -sf /dev/stderr ${RESTY_HOME}/nginx/logs/error.log
 
-  $RESTY_HOME/luajit/bin/luarocks install lua-messagepack 0.5.1 \
+  $RESTY_HOME/luajit/bin/luarocks install lua-messagepack 0.5.4 \
       && $RESTY_HOME/luajit/bin/luarocks install lua-resty-uuid 1.1 \
-      && $RESTY_HOME/luajit/bin/luarocks install lua-resty-http 0.10 \
+      && $RESTY_HOME/luajit/bin/luarocks install lua-resty-http 0.17.2 \
       && $RESTY_HOME/luajit/bin/luarocks install lua-resty-cookie 0.1.0 \
       && $RESTY_HOME/luajit/bin/luarocks install lua-resty-rollbar 0.1.0 \
       && $RESTY_HOME/luajit/bin/luarocks install busted

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   test:
     build: .

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,8 +5,6 @@ function wait_no_limit() {
   wait $!
 }
 
-# export PATH=$PATH:/usr/local/openresty/bin:/usr/local/openresty/luajit/bin
-
 echo "============="
 echo "Container ready, run 'docker compose exec test busted specs' to execute tests"
 echo "============="

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ function wait_no_limit() {
 # export PATH=$PATH:/usr/local/openresty/bin:/usr/local/openresty/luajit/bin
 
 echo "============="
-echo "Container ready, run 'docker-compose exec test busted specs' to execute tests"
+echo "Container ready, run 'docker compose exec test busted specs' to execute tests"
 echo "============="
 
 trap "exit 0" TERM INT

--- a/specs/lib/resty/rollbar_spec.lua
+++ b/specs/lib/resty/rollbar_spec.lua
@@ -1,24 +1,66 @@
-local match = require 'luassert.match'
+local assert      = require 'luassert.assert'
+local stub        = require 'luassert.stub'
+local describe    = describe ---@diagnostic disable-line: undefined-global
+local it          = it ---@diagnostic disable-line: undefined-global
+local before_each = before_each ---@diagnostic disable-line: undefined-global
+local rollbar     = require 'resty.rollbar'
 
 describe('rollbar.report', function()
-  it('should not do anything if the token is empty', function()
-    local rollbar = require('resty.rollbar')
-    rollbar.reset()
-    stub(ngx.timer, 'at')
+  describe('without token', function()
+    before_each(function()
+      rollbar.reset()
+    end)
 
-    rollbar.report(rollbar.ERR, 'test message')
+    it('should not do anything if the token is empty', function()
+      stub(ngx.timer, 'at')
 
-    assert.stub(ngx.timer.at).was_not_called()
+      rollbar.report(rollbar.ERR, 'test message')
+
+      assert.stub(ngx.timer.at).was_not_called()
+    end)
   end)
 
-  -- it('should call send_request in a light thread', function()
-  --   local rollbar = require('resty.rollbar')
-  --   rollbar.reset()
-  --   rollbar.set_token('TEST TOKEN')
+  describe('with token', function()
+    before_each(function()
+      rollbar.reset()
+      rollbar.set_token('TEST TOKEN')
+    end)
 
-  --   rollbar.report(rollbar.ERR, 'test message')
+    it('should call read_request_info if req_info is not provided', function()
+      stub(rollbar, 'read_request_info')
 
-  --   assert.stub(ngx.timer.at).was_called()
-  --   assert.stub(ngx.timer.at).was_called_with(match._, match._, match._, match._, match._, match._)
-  -- end)
+      rollbar.report(rollbar.ERR, 'test message')
+
+      assert.stub(rollbar.read_request_info).was_called()
+    end)
+
+    it('should call read_request_info if req_info is nil', function()
+      stub(rollbar, 'read_request_info')
+
+      rollbar.report(rollbar.ERR, 'test message')
+
+      assert.stub(rollbar.read_request_info).was_called()
+    end)
+
+    it('should not call read_request_info if req_info is an empty table', function()
+      stub(rollbar, 'read_request_info')
+
+      rollbar.report(rollbar.ERR, 'test message', {})
+
+      assert.stub(rollbar.read_request_info).was_not_called()
+    end)
+
+    it('should not call read_request_info if req_info is provided', function()
+      stub(rollbar, 'read_request_info')
+
+      rollbar.report(rollbar.ERR, 'test message', {
+        method = 'GET',
+        url = 'http://example.com',
+        headers = { ['Content-Type'] = 'application/json' },
+        query_string = 'foo=bar',
+      })
+
+      assert.stub(rollbar.read_request_info).was_not_called()
+    end)
+  end)
 end)


### PR DESCRIPTION
This PR address https://github.com/Scalingo/lua-resty-rollbar/issues/6. The `rollbar.report` method is now usable no matter the Nginx phase you are in. I also added a bit of comments to help users that would like to use this library. Finally, I updated dependencies that were outdated since years (including the OpenResty versions).

Another PR will follow to release version `0.2.0` that will include this change.

Fix https://github.com/Scalingo/lua-resty-rollbar/issues/6