### PR TITLE
feat(build): Publish new releases to LuaRocks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install LuaRocks
+        run: |
+          sudo apt-get update
+          sudo apt-get install luarocks
+
       - name: Set up variables
         id: vars
         run: |
@@ -44,3 +49,9 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to LuaRocks
+        run: |
+          # A JSON library is required to upload the rockspec. Dkjson supports Lua >= 5.1
+          luarocks install --local dkjson
+          luarocks upload --api-key=${{ secrets.LUAROCKS_API_KEY }} lua-resty-rollbar-${{ env.VERSION }}.rockspec

--- a/README.md
+++ b/README.md
@@ -8,18 +8,10 @@ stack traces. Errors are sent to Rollbar asynchronously in a light thread.
 
 ## Installation
 
-As of version `0.2.0`, the project is unfortunately not published to LuaRocks because we are having trouble getting an answer on our Github issue to transfer the project (https://github.com/luarocks/luarocks-site/issues/218).
-
-However, you can install the project directly using the rockspec URL:
+The dependency is [available on LuaRocks](https://luarocks.org/modules/scalingo/lua-resty-rollbar):
 
 ```bash
-luarocks install 'https://github.com/Scalingo/lua-resty-rollbar/releases/download/0.2.0-1/lua-resty-rollbar-0.2.0-1.rockspec'
-```
-
-If you are looking for older versions, they are [available on LuaRocks directly](https://luarocks.org/modules/etiennem/lua-resty-rollbar):
-
-```bash
-luarocks install lua-resty-rollbar 0.1.0
+luarocks install lua-resty-rollbar 0.2.0-1
 ```
 
 ## Usage
@@ -72,14 +64,4 @@ docker compose exec test busted specs
 1. Open a new PR to update the library version in `lib/resty/rollbar.lua`. The version should follow the [SemVer](https://semver.org/) standard.
 2. Get the PR merged
 3. Create and push a new tag to the repository. The name of the tag will become the version. Version name should follow this pattern `X.Y.Z-I`, where `X.Y.Z` is the SemVer version and `I` an increment starting at 1. The increment should only be used if the same version should be republished.
-4. A Github Actions will automatically generate and publish the release.
-
-### (Optional) Publish on LuaRocks
-
-Once the Github release has been created, the library can optionnally be published to LuaRocks. To do so, download the version `rockspec` file from the Github release and execute the following command:
-
-```bash
-luarocks upload --api-key=<API key> ./lua-resty-rollbar-<VERSION>.rockspec
-```
-
-The API key can be found on the [LuaRocks settings](https://luarocks.org/settings/api-keys).
+4. A Github Actions will automatically generate and publish the release to Github. The release will also be published to LuaRocks automatically.


### PR DESCRIPTION
Automatically publish new releases to LuaRocks.

This PR has been QA'd on a personal repository.

Before merging this PR, you need to create a new secret `LUAROCKS_API_KEY` on Github with the LuaRocks API key.

Fix #9