### PR TITLE
bump(openresty): to 1.27.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:1.27.1.1-jammy
+FROM openresty/openresty:1.27.1.2-jammy
 
 LABEL maintainer="Scalingo Team <tech@scalingo.com>"
 


### PR DESCRIPTION
This PR fixes the build error discussed here: https://scalingo.slack.com/archives/C67P0UZ1C/p1760001688119159

Fixes issue #12 